### PR TITLE
Make watch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,14 @@ lint: default.nix
 		--attr dev \
 		--run "hlint $(PROJECT_ROOT)/src $(PROJECT_ROOT)/test"
 
+.PHONY: watch
+watch: default.nix
+	@echo "Running ghcid"
+	@nix-shell \
+		--pure ./nix \
+		--attr dev \
+		--run "ghcid '--command=cabal v2-repl'"
+
 .PHONY: nix-build
 nix-build: default.nix
 	@echo "Running nix-build"

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -23,6 +23,7 @@ let
 
   devUtils = [
     cabal-install
+    haskellPackages.ghcid
     hlint
   ];
 


### PR DESCRIPTION
Add a `watch` target to the Makefile so we can easily spin up ghcid during local development.