### PR TITLE
GHC with Criterion

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -21,9 +21,14 @@ let
     nix
   ];
 
+  devDrv = hlib.overrideCabal drv (old: rec {
+    libraryHaskellDepends = old.libraryHaskellDepends ++ [
+      haskellPackages.criterion
+    ];
+  });
+
   devUtils = [
     cabal-install
-    haskellPackages.criterion
     haskellPackages.ghcid
     hlint
   ];
@@ -39,12 +44,12 @@ in
       paths = [ pkg ] ++ runtimeDeps;
     };
 
-    dev = drv.env.overrideAttrs (old: rec {
+    dev = devDrv.env.overrideAttrs (old: rec {
       buildInputs = old.buildInputs ++ runtimeDeps ++ devUtils;
     });
 
     shell = haskellPackages.shellFor {
-      packages = p: [ drv ];
+      packages = p: [ devDrv ];
       buildInputs = runtimeDeps ++ devUtils;
       shellHook = builtins.readFile ./prompt.sh;
     };


### PR DESCRIPTION
The way originally added criterion simply ensured the criterion library was present in the nix store, but didn't register it with ghc.