### PR TITLE
Implement Column.grid using IntMap

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
 { mkDerivation, aeson, ansi-wl-pprint, attoparsec, base, bytestring
-, Cabal, dhall, directory, filemanip, filepath, haskeline, hlibgit2
-, hspec, main-tester, optparse-applicative, prettyprinter
-, regex-tdfa, safe, stdenv, temporary, terminal-size, text
-, transformers, typed-process, unix, unliftio
+, Cabal, containers, dhall, directory, filemanip, filepath
+, haskeline, hlibgit2, hspec, main-tester, optparse-applicative
+, prettyprinter, regex-tdfa, safe, stdenv, temporary, terminal-size
+, text, transformers, typed-process, unix, unliftio
 }:
 mkDerivation {
   pname = "shellbit";
@@ -11,8 +11,8 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson ansi-wl-pprint attoparsec base bytestring Cabal dhall
-    directory filemanip filepath haskeline hlibgit2
+    aeson ansi-wl-pprint attoparsec base bytestring Cabal containers
+    dhall directory filemanip filepath haskeline hlibgit2
     optparse-applicative prettyprinter safe temporary terminal-size
     text transformers typed-process unix unliftio
   ];

--- a/shellbit.cabal
+++ b/shellbit.cabal
@@ -36,6 +36,7 @@ library
     , base                 >= 4.12     && < 5
     , bytestring           >= 0.10     && < 0.11
     , Cabal                >= 2.4      && < 2.5
+    , containers           >= 0.6.0.1  && < 0.7
     , dhall                >= 1.19     && < 1.20
     , directory            >= 1.3      && < 1.4
     , filemanip            >= 0.3      && < 0.4


### PR DESCRIPTION
Benchmarking collections of 50 to 100 elements showed the IntMap implementation takes roughly 2/3 the time that the original version took.

At 500 elements it benchmarked at 1/4 the time of the original.

For collections of fewer than 30 elements, the original implementation is slightly faster, though at that size performance isn't actually an issue.

___

Benchmarks: https://gist.github.com/ivanbrennan/9f55ee766e4fc1102768582f9b8c6b4a